### PR TITLE
Make eqdist more robust

### DIFF
--- a/src/movement.jl
+++ b/src/movement.jl
@@ -54,9 +54,19 @@ one due to the row-standardization of the movement operator).
 """
 function eqdist(M::MovementModel)
     n = M.Ωsize
-    λ, ϕ = eigs(M.M; nev = 1, which = :LM, ritzvec = true,
-                tol = 1e-10, maxiter = 1_000)
-    eq = real(ϕ)
+    tol = 1e-10
+    eq = zeros((0,))
+    while true
+        λ, ϕ = eigs(M.M; nev = 1, which = :LM, ritzvec = true,
+                    tol = tol, maxiter = 1_000, v0 = eq)
+        eq = vec(real(ϕ))
+        if any(eq .< 0)
+            tol *= 1e-1
+        else
+            break
+        end
+    end
+
     eq ./= sum(eq)
     PopState(reshape(eq, n...))
 end

--- a/test/test-movement.jl
+++ b/test/test-movement.jl
@@ -1,6 +1,7 @@
 @testset "Movement models" begin
     @test eqdist_ap isa PopState
     @test eqdist_ap0.P ≈ eqdist_eigvecs
+    @test all(eqdist_ap.P .> 0)
     @test all(sum(move.M; dims = 1) .≈ 1)
     @test all(0 .≤ eqdist_ap0.P .≤ 1)
     @test sum(eqdist_ap0) ≈ 1.0


### PR DESCRIPTION
Continue reducing tolerance on Arpack solver until real part of the first
eigenvector is strictly positive.