### PR TITLE
Don't default to broadcasting the preference function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
   - windows
 julia:
-  - 1.3
+  - 1.6
   - nightly
 notifications:
   email: false

--- a/src/targeting.jl
+++ b/src/targeting.jl
@@ -110,6 +110,6 @@ function DynamicPreferentialTargeting(preference::AbstractArray,
 end
 
 function reset!(dynpref::DynamicPreferentialTargeting, pop::PopState)
-    dynpref.preference = weights(dynpref.pref_fn.(pop.P))
+    dynpref.preference = weights(dynpref.pref_fn(pop.P))
 end
 


### PR DESCRIPTION
Dynamic preferential targeting should use a preference function that accepts the matrix of abundances rather than performing scalar operations and broadcasting. This is needed to allow a closure over spatially varying catchability.